### PR TITLE
fix bug with sending a message in the snitch

### DIFF
--- a/lib/snitcher.rb
+++ b/lib/snitcher.rb
@@ -19,8 +19,9 @@ module Snitcher
   #
   # Returns true if the check-in succeeded or false if it failed
   def snitch(token, opts = {})
-    uri     = URI.parse("https://nosnch.in/#{token}")
-    timeout = opts.fetch(:timeout, 2)
+    uri       = URI.parse("https://nosnch.in/#{token}")
+    uri.query = URI.encode_www_form(:m => opts[:message]) if opts[:message]
+    timeout   = opts.fetch(:timeout, 2)
 
     opts = {
       :open_timeout => timeout,
@@ -30,10 +31,6 @@ module Snitcher
     }
 
     Net::HTTP.start(uri.host, uri.port, opts) do |http|
-      if message = opts[:message]
-        uri.query = URI.encode_www_form(:m => message)
-      end
-
       request = Net::HTTP::Get.new(uri.request_uri)
       request["User-Agent"] = user_agent
 

--- a/spec/snitcher_spec.rb
+++ b/spec/snitcher_spec.rb
@@ -50,7 +50,7 @@ describe Snitcher do
       it "includes the message as a query param" do
         Snitcher.snitch(token, :message => "A thing just happened")
 
-        expect(a_request(:get, "https://nosnch.in/#{token}?m=A%20thing%20just%20happened"))
+        expect(a_request(:get, "https://nosnch.in/#{token}?m=A%20thing%20just%20happened")).to have_been_made
       end
     end
 


### PR DESCRIPTION
The `opts` variable was being overwritten before the `Net::HTTP.start` call. 
Also the test wasn't checking that the request was being made.