### PR TITLE
Made it so that URI encoded Snitches with spaces correctly

### DIFF
--- a/lib/snitcher/api/client.rb
+++ b/lib/snitcher/api/client.rb
@@ -227,7 +227,8 @@ class Snitcher::API::Client
   #
   # @return [Array<String>] list of the remaining tags on the Snitch.
   def remove_tag(token, tag)
-    delete("/v1/snitches/#{token}/tags/#{tag}")
+    path = "/v1/snitches/#{token}/tags/#{tag}"
+    delete(URI.encode(path))
   end
 
   # Pauses a Snitch if it can be paused. Snitches can only be paused if their

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -442,6 +442,14 @@ describe Snitcher::API::Client do
 
       expect(a_request(:delete, url)).to have_been_made.once
     end
+    
+    it "properly escapes tags with spaces" do
+      request = stub_request(:delete, "#{snitch_url}/c2354d53d2/tags/tag%20with%20spaces").
+        to_return(:body => body, :status => 200)
+
+      client.remove_tag(token, "tag with spaces")
+      expect(request).to have_been_made.once
+    end
 
     context "when successful" do
       it "returns an array of the snitch's remaining tags" do


### PR DESCRIPTION
Before Snitches with spaces did not get encoded correctly
since there was a space in the URI, now they will be encoded
properly so that there is not an HTTP error.