### PR TITLE
Replace tagged_snitches with filters on #snitches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ Returns a Snitch.
 ### Retrieve Snitches That Match a Set of Tags
 
 ```ruby
-tags = ["critical", "sales"]
-client.tagged_snitches(tags)
+client.snitches(tags: ["critical", "sales"])
 ```
 
 Returns an array of Snitches.

--- a/examples/api.rb
+++ b/examples/api.rb
@@ -39,7 +39,7 @@ snitch.tags = client.add_tags(snitch.token, ["production", "critical issues"])
 snitch.tags = client.remove_tag(snitch.token, "critical issues")
 
 # Get a list of Snitches tagged with "production"
-production = client.tagged_snitches(["production"])
+production = client.snitches(tags: ["production"])
 puts "Production Snitches:"
 production.each { |s| puts "  - #{s.inspect}"}
 

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -60,6 +60,22 @@ describe Snitcher::API::Client do
       expect(client.snitches).to be_a(Array)
       expect(client.snitches.first).to be_a(Snitcher::API::Snitch)
     end
+
+    it "allows filtering by a tag" do
+      request = stub_request(:get, "#{snitch_url}?tags=production")
+        .to_return(body: body, status: 200)
+
+      client.snitches(tags: "production")
+      expect(request).to have_been_made.once
+    end
+
+    it "allows filtering by multiple tags" do
+      request = stub_request(:get, "#{snitch_url}?tags=phoenix%20foundary,murggle")
+        .to_return(body: body, status: 200)
+
+      client.snitches(tags: ["phoenix foundary", "murggle"])
+      expect(request).to have_been_made.once
+    end
   end
 
   describe "#snitch" do
@@ -96,77 +112,6 @@ describe Snitcher::API::Client do
 
     it "returns the snitch" do
       expect(client.snitch(token)).to be_a(Snitcher::API::Snitch)
-    end
-  end
-
-  describe "#tagged_snitches" do
-    let(:tags)  { ["sneetch", "belly"] }
-    let(:url)   { "#{snitch_url}?tags=sneetch,belly" }
-    let(:body)  { '[
-                     {
-                       "token": "c2354d53d2",
-                       "href": "/v1/snitches/c2354d53d2",
-                       "name": "Best Kind of Sneetch on the Beach",
-                       "tags": [
-                         "sneetch",
-                         "belly",
-                         "star-belly"
-                       ],
-                       "status": "pending",
-                       "checked_in_at": "",
-                       "type": {
-                         "interval": "hourly"
-                       }
-                     },
-                     {
-                       "token": "c2354d53d3",
-                       "href": "/v1/snitches/c2354d53d3",
-                       "name": "Have None Upon Thars",
-                       "tags": [
-                         "sneetch",
-                         "belly",
-                         "plain-belly"
-                       ],
-                       "status": "pending",
-                       "checked_in_at": "",
-                       "type": {
-                         "interval": "hourly"
-                       }
-                     }
-                   ]'
-                }
-
-    before do
-      stub_request(:get, stub_url).to_return(:body => body, :status => 200)
-    end
-
-    it "pings API with the api_key" do
-      client.tagged_snitches(tags)
-
-      expect(a_request(:get, url)).to have_been_made.once
-    end
-
-    it "returns the snitches" do
-      expect(client.tagged_snitches(tags)).to be_a(Array)
-      expect(client.tagged_snitches(tags).first).to be_a(Snitcher::API::Snitch)
-    end
-
-    it "supports spaces in tags" do
-      request = stub_request(:get, "#{snitch_url}?tags=phoenix%20foundary,murggle").
-        to_return(body: body, status: 200)
-
-      client.tagged_snitches("phoenix foundary", "murggle")
-
-      expect(request).to have_been_made.once
-    end
-
-    it "allows an array to be passed for tags" do
-      request = stub_request(:get, "#{snitch_url}?tags=murggle,gurgggle").
-        to_return(body: body, status: 200)
-
-      client.tagged_snitches(["murggle", "gurgggle"])
-
-      expect(request).to have_been_made.once
     end
   end
 


### PR DESCRIPTION
The `#tagged_snitches` method exposed functionality on the same endpoint
that `#snitches` calls. It makes more sense to have this be a parameter
for `#snitches` rather than it's own method. This reduces the footprint
of the client slightly and better fits with the API documentation.