### PR TITLE
Allow Snitcher.snitch to take a block

### DIFF
--- a/lib/snitcher.rb
+++ b/lib/snitcher.rb
@@ -29,6 +29,17 @@ module Snitcher
   #
   # @return [Boolean] if the check-in succeeded.
   def snitch!(token, opts = {})
+    if block_given?
+      snitch_start = Time.now
+      begin
+        result = yield
+        opts[:status] = 0
+      rescue StandardError => e
+        opts[:message] = e.message
+        opts[:status] = 1
+      end
+    end
+
     params = {}
     params[:m] = opts[:message] if opts[:message]
 


### PR DESCRIPTION
I was moving some stuff into Ruby that was previously using [Field Agent](https://deadmanssnitch.com/docs/field-agent). I found myself wanting a block syntax to mimic the niceties of Field Agent. 

This could be enough, but tracking the duration would be a nice extra. Anything else it should do?